### PR TITLE
Fix TypeScript any type errors

### DIFF
--- a/src/components/Checkbox.stories.tsx
+++ b/src/components/Checkbox.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import Checkbox from "./Checkbox";
+import Checkbox, { Checkbox as CheckboxProps } from "./Checkbox";
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,
@@ -11,17 +11,17 @@ export default meta;
 
 type Story = StoryObj<typeof Checkbox>;
 
-const CheckboxWithState = (args: any) => {
+const CheckboxWithState = (args: CheckboxProps) => {
   const [checked, setChecked] = useState(false);
   return <Checkbox {...args} checked={checked} onChange={setChecked} />;
 };
 
-const CheckboxWithStateChecked = (args: any) => {
+const CheckboxWithStateChecked = (args: CheckboxProps) => {
   const [checked, setChecked] = useState(true);
   return <Checkbox {...args} checked={checked} onChange={setChecked} />;
 };
 
-const CheckboxWithStateDisabled = (args: any) => {
+const CheckboxWithStateDisabled = (args: CheckboxProps) => {
   const [checked, setChecked] = useState(false);
   return (
     <Checkbox {...args} checked={checked} onChange={setChecked} disabled />

--- a/src/components/CollectionCountIconButton.stories.tsx
+++ b/src/components/CollectionCountIconButton.stories.tsx
@@ -11,7 +11,16 @@ export default meta;
 
 type Story = StoryObj<typeof CollectionCountIconButton>;
 
-const CollectionCountIconButtonWithState = (args: any) => {
+type CollectionCountIconButtonProps = {
+  checked: boolean;
+  count: number;
+  disabled?: boolean;
+  className?: string;
+  type?: "button" | "submit" | "reset";
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+const CollectionCountIconButtonWithState = (args: CollectionCountIconButtonProps) => {
   const [checked, setChecked] = useState(false);
   const count = checked ? 1 : 0;
   return (

--- a/src/components/CountIconButton.stories.tsx
+++ b/src/components/CountIconButton.stories.tsx
@@ -11,7 +11,16 @@ export default meta;
 
 type Story = StoryObj<typeof CountIconButton>;
 
-const CountIconButtonWithState = (args: any) => {
+type CountIconButtonProps = {
+  checked: boolean;
+  count: number;
+  disabled?: boolean;
+  className?: string;
+  type?: "button" | "submit" | "reset";
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+};
+
+const CountIconButtonWithState = (args: CountIconButtonProps) => {
   const [checked, setChecked] = useState(false);
   const count = checked ? 1 : 0;
   return (

--- a/src/components/FollowButton.stories.tsx
+++ b/src/components/FollowButton.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import FollowButton from "./FollowButton";
+import FollowButton, { FollowButtonProps } from "./FollowButton";
 
 const meta: Meta<typeof FollowButton> = {
   component: FollowButton,
@@ -11,7 +11,7 @@ export default meta;
 
 type Story = StoryObj<typeof FollowButton>;
 
-const FollowButtonWithState = (args: any) => {
+const FollowButtonWithState = (args: FollowButtonProps) => {
   const [checked, setChecked] = useState(false);
   return (
     <FollowButton
@@ -22,7 +22,7 @@ const FollowButtonWithState = (args: any) => {
   );
 };
 
-const FollowButtonWithStateLarge = (args: any) => {
+const FollowButtonWithStateLarge = (args: FollowButtonProps) => {
   const [checked, setChecked] = useState(false);
   return (
     <FollowButton
@@ -34,7 +34,7 @@ const FollowButtonWithStateLarge = (args: any) => {
   );
 };
 
-const FollowButtonWithStateMedium = (args: any) => {
+const FollowButtonWithStateMedium = (args: FollowButtonProps) => {
   const [checked, setChecked] = useState(false);
   return (
     <FollowButton

--- a/src/components/TextField.stories.tsx
+++ b/src/components/TextField.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
-import TextField from "./TextField";
+import TextField, { TextFieldProps } from "./TextField";
 
 const meta: Meta<typeof TextField> = {
   component: TextField,
@@ -11,7 +11,7 @@ export default meta;
 
 type Story = StoryObj<typeof TextField>;
 
-const TextFieldWithState = (args: any) => {
+const TextFieldWithState = (args: TextFieldProps) => {
   const [value, setValue] = useState("");
   return <TextField {...args} value={value} onChange={setValue} />;
 };


### PR DESCRIPTION
Fix TypeScript `@typescript-eslint/no-explicit-any` errors in Storybook files by specifying proper types.