### PR TITLE
Fix button label and remove sample tags

### DIFF
--- a/src/app/(me)/mypage/post/TagDialog.tsx
+++ b/src/app/(me)/mypage/post/TagDialog.tsx
@@ -59,7 +59,7 @@ const TagDialog: React.FC<TagDialogProps> = ({
   const handleClose = onClose || (() => {});
 
   return (
-    <div className="fixed inset-0 z-50 bg-[var(--surface)] flex flex-col min-h-screen w-full max-w-[480px] mx-auto  gap-[24px]">
+    <div className="fixed inset-0 z-[100] bg-[var(--surface)] flex flex-col min-h-screen w-full max-w-[480px] mx-auto  gap-[24px]">
       {/* 閉じるボタン */}
       <div className="h-[64px] flex items-center px-[16px]">
         <IconButton icon={<CloseIcon />} onClick={handleClose} />

--- a/src/stories/TagDialog.stories.tsx
+++ b/src/stories/TagDialog.stories.tsx
@@ -14,6 +14,6 @@ type Story = StoryObj<typeof TagDialog>;
 
 export const Default: Story = {
   args: {
-    initialTags: ["タグ1", "タグ2", "タグ3"],
+    initialTags: [],
   },
 };


### PR DESCRIPTION
Fix TagDialog 'Add' button visibility in production and remove Storybook sample tags.

The 'Add' button in the TagDialog was obscured by the post screen's FixedBottomContainer in production, appearing as a 'Post' button. Increasing the TagDialog's z-index ensures it renders correctly on top. Unnecessary sample tags were also removed from the Storybook configuration.